### PR TITLE
ci: introduces basic CI pipeline

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: main
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: latest
+      - run: npx prettier . --check

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ by setting the `sprocket.server.path` configuration option.
 
 ## 🎨 Features
 
-* **Basic syntax highlighting** using a complete and up-to-date [TextMate
+- **Basic syntax highlighting** using a complete and up-to-date [TextMate
   grammar](https://macromates.com/manual/en/language_grammars). _This grammar is slated
   to drive GitHub's syntax highlighting for WDL files [in a future
   release](https://github.com/github-linguist/linguist/pull/6972)_.
-* **Document and workspace diagnostics** courtesy of the language server protocol
+- **Document and workspace diagnostics** courtesy of the language server protocol
   implementation provided by`sprocket analyzer`.
-* **Code snippets** for common WDL constructs and conventions.
+- **Code snippets** for common WDL constructs and conventions.
 
 _**Note:** more features will be added as `sprocket` is developed. Please check out the
 activity on the [Sprocket repository](https://github.com/stjude-rust-labs/sprocket) to
@@ -120,7 +120,6 @@ yarn compile
 
 This command will automatically be run when you start the extension in the
 development environment or when packaging the extension.
-
 
 ## Running The Development Extension
 


### PR DESCRIPTION
Adds a basic CI pipeline to ensure that everything stays formatted appropriately. Since we've [decided on using `prettier`](#3), I just went with that.