### PR TITLE
revise: changes name from `WDL` to `wdl`

### DIFF
--- a/syntaxes/wdl.tmGrammar.json
+++ b/syntaxes/wdl.tmGrammar.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "WDL",
+  "name": "wdl",
   "patterns": [
     {
       "include": "#single-number-sign-comment"


### PR DESCRIPTION
[`shiki.js`](https://github.com/shikijs/shiki), which I'm using for the new WDL documentation, detects the language name from this key. Either it or Vitepress appear not to like the all uppercase name, (` ```WDL `) as they convert it to lowercase on my behalf. Indeed, it appears most languages are lowercase named.

Thus, I decided to update the name in this PR. I took a quick look at GitHub linguist, and I don't think this should affect anything with the language being rendered here. To be honest, I am not 100% certain on that though. I'll look at it a bit more this week, but I'm also open to others taking a look.