### PR TITLE
Attempt to restart lsp atleast once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added a feature to automatically install and update `sprocket` from GitHub ([#7](https://github.com/stjude-rust-labs/sprocket-vscode/pull/7)).
+- Added automatic retry (1 attempt) for Sprocket language server on unexpected termination
 
 ## 0.2.0 - 08-16-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Added automatic retry for Sprocket language server on unexpected termination.
+
 ## 0.3.0 - 10-22-2024
 
 ### Added
 
 - Added a feature to automatically install and update `sprocket` from GitHub ([#7](https://github.com/stjude-rust-labs/sprocket-vscode/pull/7)).
-- Added automatic retry (1 attempt) for Sprocket language server on unexpected termination
 
 ## 0.2.0 - 08-16-2024
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -415,8 +415,7 @@ async function startServer() {
           };
         }
 
-        // We will retry atleast once if sprocket was initialized.
-        // Can we add a configuration property to allow for more retries?
+        // We will retry at least once if sprocket was initialized.
         crashReports++;
         if (crashReports <= 1) {
           setStatus(Status.Working, "Sprocket has terminated. Restarting...");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,12 @@ import {
 import {
   ErrorAction,
   CloseAction,
-  CancellationToken,
+  ResponseError,
+  InitializeError,
 } from "vscode-languageclient";
 import { getApi, FileDownloader } from "@microsoft/vscode-file-downloader-api";
 import "node-fetch";
-import path, { format } from "path";
+import path from "path";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import * as tar from "tar";
 import extract from "extract-zip";
@@ -23,6 +24,8 @@ let context: vscode.ExtensionContext | undefined;
 let client: LanguageClient | undefined;
 let channel: vscode.OutputChannel;
 let statusBar: vscode.StatusBarItem;
+let initializationError: ResponseError<InitializeError> | undefined = undefined;
+let crashReports = 0;
 
 enum Status {
   Normal,
@@ -91,11 +94,20 @@ function registerCommands(context: vscode.ExtensionContext) {
 
 async function stopServer() {
   if (!client) {
-    return undefined;
+    channel.appendLine("No client to stop");
+    return;
   }
 
-  await client.stop();
-  client = undefined;
+  try {
+    if (client.needsStop() && client.isRunning()) {
+      await client.stop();
+    }
+  } catch (e: any) {
+    channel.appendLine(`Error stopping server: ${e.message}`);
+  } finally {
+    await client.dispose();
+    client = undefined;
+  }
 }
 
 function formatDownloadUri(version: string): vscode.Uri | undefined {
@@ -379,18 +391,51 @@ async function startServer() {
   let clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "wdl" }],
     outputChannel: channel,
+    initializationFailedHandler: (error: ResponseError<InitializeError> | Error | any) => {
+      initializationError = error;
+      setStatus(Status.Error, "Failed to initialize Spocket language-service. Please check your configuration settings and reload this window.");
+      return false;
+    },
     errorHandler: {
       error: (error, message, count) => {
         return {
-          action: ErrorAction.Continue,
+          action: ErrorAction.Shutdown,
           message: `Sprocket encountered an error: ${error}`,
           handled: false,
         };
       },
-      closed: () => {
-        setStatus(Status.Error, `Sprocket has terminated`);
+      closed: async () => {
+        if (initializationError !== undefined) {
+          channel.appendLine("Initialization error: " + initializationError.message);
+          return {
+            action: CloseAction.DoNotRestart,
+            // This won't show an error dialog to the user,
+            // allowing us to display a custom error later.
+            message: "",
+          };
+        }
 
-        // TODO: implement retry logic if sprocket was initialized.
+        // We will retry atleast once if sprocket was initialized.
+        // Can we add a configuration property to allow for more retries?
+        crashReports++;
+        if (crashReports <= 1) {
+          setStatus(Status.Working, "Sprocket has terminated. Restarting...");
+          channel.appendLine("Attempting restart...");
+          try {
+            await restartServer();
+            channel.appendLine("Successfully restarted Sprocket");
+            return {
+              action: CloseAction.DoNotRestart,
+              handled: true,
+            };
+          } catch (e: any) {
+            channel.appendLine(`Restart failed: ${e.message}`);
+          }
+        }
+
+        // this was not an initialization error, so we don't know what went wrong yet
+        // stop attempting to restart
+        setStatus(Status.Error, `Sprocket has terminated`);
         return {
           action: CloseAction.DoNotRestart,
           message: "Sprocket has terminated",
@@ -443,12 +488,13 @@ async function startServer() {
 }
 
 async function restartServer() {
-  await stopServer();
-
+  channel.appendLine("Restarting Sprocket server...");
   try {
+    await stopServer();
     await startServer();
   } catch (e: any) {
-    setStatus(Status.Error, `Failed to activate start server: ${e.message}`);
+    channel.appendLine(`Failed to restart Sprocket server: ${e.message}`);
+    setStatus(Status.Error, `Failed to restart Sprocket: ${e.message}`);
     throw e;
   }
 }


### PR DESCRIPTION
Add automatic retry to the extension so language server attempts to restart at least once when it terminates unexpectedly (e.g. due to a crash). Previously the server would simply stop without retrying.

took the template from other repo
- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).

- Closes #19

### After some local testing

1. Simulating crash using a custom command (internal crash)

```ts
context.subscriptions.push(
  vscode.commands.registerCommand("sprocket.simulateCrash", async () => {
    if (client) {
      channel.appendLine("Simulating Sprocket server crash...");
      await client.stop();
      client = undefined;
      const closedHandler = clientOptions.errorHandler?.closed;
      if (closedHandler) {
        await closedHandler();
      }
    } else {
      channel.appendLine("No running Sprocket server to crash");
    }
  })
);
```

Debug Output:

```diff
Sprocket extension is initializing...
Spawning `sprocket` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.10.1
+ Simulating Sprocket server crash...
Attempting restart...
Restarting Sprocket server...
No client to stop
Spawning `sprocket` with arguments `["analyzer","-q"]`
[Error - 4:25:19 AM] Server process exited with code 0.
Connected to Sprocket LSP server version 0.10.1
+ Successfully restarted Sprocket
```

2. Killing the underlying server process i.e `sprocket analyze` (external crash)
   using

```bash
ps a | grep "[s]procket analyzer" | awk '{print $1}' | xargs kill
```

Debug Output

```diff
Sprocket extension is initializing...
Spawning `sprocket` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.10.1
+ Attempting restart...
+ Restarting Sprocket server...
[Error - 4:26:55 AM] Stopping server failed
Error: Connection is disposed.
    at throwIfClosedOrDisposed (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/connection.js:832:19)
    at Object.sendRequest (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/connection.js:1000:13)
    at Object.shutdown (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/common/client.js:1578:31)
    at /projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/common/client.js:971:30
    at LanguageClient2.shutdown (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/common/client.js:974:9)
    at LanguageClient2.stop (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/common/client.js:935:21)
    at LanguageClient2.stop (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/node/main.js:150:22)
    at stopServer (/projects/stjude-rust-labs/sprocket-vscode/src/extension.ts:122:20)
    at restartServer (/projects/stjude-rust-labs/sprocket-vscode/src/extension.ts:512:11)
    at Object.closed (/projects/stjude-rust-labs/sprocket-vscode/src/extension.ts:444:19)
    at LanguageClient2.handleConnectionClosed (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/common/client.js:1164:72)
    at LanguageClient2.handleConnectionClosed (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/node/main.js:180:22)
    at closeHandler (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-languageclient/lib/common/client.js:1142:18)
    at CallbackList.invoke (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/events.js:55:39)
    at _Emitter.fire (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/events.js:117:36)
    at closeHandler (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/connection.js:314:26)
    at CallbackList.invoke (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/events.js:55:39)
    at _Emitter.fire (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/events.js:117:36)
    at StreamMessageReader.fireClose (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/messageReader.js:41:27)
    at Socket.<anonymous> (/projects/stjude-rust-labs/sprocket-vscode/node_modules/vscode-jsonrpc/lib/common/messageReader.js:126:42)
    at Socket.emit (node:events:530:35)
    at Pipe.<anonymous> (node:net:343:12)
    at Pipe.callbackTrampoline (node:internal/async_hooks:130:17)
Error stopping server: Connection is disposed.
Spawning `sprocket` with arguments `["analyzer","-q"]`
[Error - 4:26:56 AM] Server process exited with signal SIGTERM.
+ Connected to Sprocket LSP server version 0.10.1
+ Successfully restarted Sprocket
[Error - 4:26:56 AM] Connection to server got closed. Server will not be restarted.
```

In both the cases, the server was successfully restarted and showed diagnostics as expected.

## More Extendable
We can add configurations to give user the option to customize the amount of max-retries
