### PR TITLE
Removed unused imports from issue #22

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,10 @@ import {
 import {
   ErrorAction,
   CloseAction,
-  CancellationToken,
 } from "vscode-languageclient";
 import { getApi, FileDownloader } from "@microsoft/vscode-file-downloader-api";
 import "node-fetch";
-import path, { format } from "path";
+import path from "path";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 import * as tar from "tar";
 import extract from "extract-zip";


### PR DESCRIPTION
This pr removes the imports, "CancellationToken" and "format", which were unused.

**Code**

`import {
...
  CancellationToken,
} from "vscode-languageclient";
import path, { format } from "path";
`

**Issue**
#22 

_edited._
