### PR TITLE
Add configurable server retry attempts - Fixes #25

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "version": "0.3.0",
   "engines": {
-    "vscode": "^1.91.0"
+    "vscode": "^1.98.0"
   },
   "license": "SEE LICENSE IN LICENSE-APACHE",
   "categories": [
@@ -60,6 +60,11 @@
         "command": "sprocket.restartServer",
         "title": "Restart Server",
         "category": "Sprocket"
+      },
+      {
+        "command": "sprocket.simulateCrash",
+        "title": "Simulate Server Crash",
+        "category": "Sprocket"
       }
     ],
     "configuration": [
@@ -93,6 +98,13 @@
           "sprocket.server.lint": {
             "type": "boolean",
             "markdownDescription": "Passes the `--lint` flag to `sprocket`; this enables additional linting checks that are not enabled by default."
+          },
+          "sprocket.server.maxRetries": {
+            "type": "number",
+            "default": 5,
+            "minimum": 0,
+            "markdownDescription": "Maximum number of times to attempt restarting the Sprocket server after termination. Set to 0 to disable automatic restarts.",
+            "scope": "window"
           }
         }
       }
@@ -121,7 +133,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
-    "@types/vscode": "^1.91.0",
+    "@types/vscode": "^1.98.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.11.0",
     "@vscode/test-cli": "^0.0.9",


### PR DESCRIPTION
Fixes #25

This PR adds a configurable setting for the number of times the extension should attempt to restart the Sprocket server after termination.

Changes:
- Added new configuration option `sprocket.server.maxRetries`
- Implemented retry counting and tracking
- Added detailed logging for server restarts
- Added proper error handling for restart attempts
- Reset crash counter on successful restarts

The setting can be configured in VS Code settings:
- Default value: 5 attempts
- Minimum value: 0 (disables automatic restarts)
- Scope: window

Testing:
1. Set different values for maxRetries in settings
2. Use the "Sprocket: Simulate Server Crash" command
3. Observe retry attempts in Output panel
4. Verify server stops after reaching maximum retries

Example logs showing proper tracking:

_Sprocket extension is initializing...
Reset crash reports counter
Raw maxRetries from config: 2
Final maxRetries value: 2
Raw maxRetries from config in startServer: 2
Maximum retry attempts set to: 2
Found previously installed Sprocket at `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` (0.11.0)
Checking for latest stable Sprocket crate version...
Latest Sprocket release is 0.11.0
Skipping update as previously installed Sprocket is newest available
Spawning `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.11.0
Raw maxRetries from config in onDidChangeConfiguration: 5
Updated maximum retry attempts to: 5
Simulating Sprocket server crash...
Server terminated (attempt 1/6)
Attempting restart (1/5)...
Restarting Sprocket server...
Raw maxRetries from config in startServer: 5
Maximum retry attempts set to: 5
Found previously installed Sprocket at `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` (0.11.0)
Checking for latest stable Sprocket crate version...
[Error - 1:53:28 PM] Server process exited with code 0.
Latest Sprocket release is 0.11.0
Skipping update as previously installed Sprocket is newest available
Spawning `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.11.0
Simulating Sprocket server crash...
Server terminated (attempt 2/6)
Attempting restart (2/5)...
Restarting Sprocket server...
Raw maxRetries from config in startServer: 5
Maximum retry attempts set to: 5
Found previously installed Sprocket at `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` (0.11.0)
Checking for latest stable Sprocket crate version...
[Error - 1:53:32 PM] Server process exited with code 0.
Latest Sprocket release is 0.11.0
Skipping update as previously installed Sprocket is newest available
Spawning `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.11.0
Simulating Sprocket server crash...
Server terminated (attempt 3/6)
Attempting restart (3/5)...
Restarting Sprocket server...
Raw maxRetries from config in startServer: 5
Maximum retry attempts set to: 5
Found previously installed Sprocket at `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` (0.11.0)
Checking for latest stable Sprocket crate version...
[Error - 1:53:37 PM] Server process exited with code 0.
Latest Sprocket release is 0.11.0
Skipping update as previously installed Sprocket is newest available
Spawning `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.11.0
Simulating Sprocket server crash...
Server terminated (attempt 4/6)
Attempting restart (4/5)...
Restarting Sprocket server...
Raw maxRetries from config in startServer: 5
Maximum retry attempts set to: 5
Found previously installed Sprocket at `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` (0.11.0)
Checking for latest stable Sprocket crate version...
[Error - 1:53:40 PM] Server process exited with code 0.
Latest Sprocket release is 0.11.0
Skipping update as previously installed Sprocket is newest available
Spawning `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.11.0
Simulating Sprocket server crash...
Server terminated (attempt 5/6)
Attempting restart (5/5)...
Restarting Sprocket server...
Raw maxRetries from config in startServer: 5
Maximum retry attempts set to: 5
Found previously installed Sprocket at `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` (0.11.0)
Checking for latest stable Sprocket crate version...
[Error - 1:53:42 PM] Server process exited with code 0.
Latest Sprocket release is 0.11.0
Skipping update as previously installed Sprocket is newest available
Spawning `c:\Users\hp\AppData\Roaming\Code\User\globalStorage\stjude-rust-labs.sprocket-vscode\file-downloader-downloads\sprocket.exe` with arguments `["analyzer","-q"]`
Connected to Sprocket LSP server version 0.11.0
Simulating Sprocket server crash...
Server terminated (attempt 6/6)
Server terminated after 5 retry attempts.
[Error - 1:53:45 PM] Server process exited with code 0._