### PR TITLE
fix: markdown & bash highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fixed doc comment matching in the WDL TextMate grammar ([#43](https://github.com/stjude-rust-labs/sprocket-vscode/pull/43)).
+- Fixed shell code highlighting in the WDL TextMate grammar ([#43](https://github.com/stjude-rust-labs/sprocket-vscode/pull/43)).
+
 ## 0.7.0 - 04-02-2026
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "scopeName": "source.wdl",
         "path": "./syntaxes/wdl.tmGrammar.json",
         "embeddedLanguages": {
-          "meta.embedded.block.shellscript": "shellscript"
+          "source.shell.embedded.wdl": "shellscript"
         }
       }
     ],

--- a/syntaxes/wdl.tmGrammar.json
+++ b/syntaxes/wdl.tmGrammar.json
@@ -1,12 +1,21 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "wdl",
+  "injections": {
+    "L:source.shell.embedded.wdl": {
+      "patterns": [
+        {
+          "include": "#placeholder"
+        }
+      ]
+    }
+  },
   "patterns": [
     {
-      "include": "#single-number-sign-comments"
+      "include": "#double-number-sign-comments"
     },
     {
-      "include": "#double-number-sign-comments"
+      "include": "#single-number-sign-comments"
     },
     {
       "comment": "version",
@@ -148,22 +157,31 @@
     }
   ],
   "repository": {
-    "single-number-sign-comments": {
-      "comment": "single number sign comments",
-      "name": "comment.line.number-sign.documentation",
-      "begin": "(?:\\s*)(?:#(?!#))",
-      "while": "(?:^|\\G)(?:\\s*)(?:#(?!#))"
-    },
     "double-number-sign-comments": {
       "comment": "double number sign comments",
-      "name": "comment.line.double-number-sign.documentation",
-      "begin": "(?:\\s*)(?:##) ?",
-      "while": "(?:^|\\G)\\s*(?:##) ?",
+      "begin": "^(\\s*)(##)",
+      "beginCaptures": {
+        "2": {
+          "name": "comment.line.double-number-sign.documentation"
+        }
+      },
+      "while": "^(\\s*)(##)",
+      "whileCaptures": {
+        "2": {
+          "name": "comment.line.double-number-sign.documentation"
+        }
+      },
       "patterns": [
         {
           "include": "text.html.markdown"
         }
       ]
+    },
+    "single-number-sign-comments": {
+      "comment": "single number sign comments",
+      "name": "comment.line.number-sign.documentation",
+      "begin": "(?:\\s*)(?:#(?!#))",
+      "while": "(?:^|\\G)(?:\\s*)(?:#(?!#))"
     },
     "input-block": {
       "comment": "`input` blocks",
@@ -210,6 +228,9 @@
         },
         {
           "include": "#bash-in-wdl"
+        },
+        {
+          "include": "source.shell"
         }
       ]
     },
@@ -237,6 +258,9 @@
         },
         {
           "include": "#bash-in-wdl"
+        },
+        {
+          "include": "source.shell"
         }
       ]
     },


### PR DESCRIPTION
Fixed the matching of doc comments (`##`) and the `embeddedLanguages` config